### PR TITLE
+ prebuild to export conf.py for Sphinx on RtD server

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,9 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.12"
-
+  jobs:
+    pre_build:
+      - "jupyter-book config sphinx a_primer_on_modern_control_algorithms/"
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   builder: html

--- a/a_primer_on_modern_control_algorithms/requirements.txt
+++ b/a_primer_on_modern_control_algorithms/requirements.txt
@@ -1,3 +1,7 @@
 jupyter-book
 matplotlib
 numpy
+sphinx-inline_tabs
+sphinx-proof
+sphinx-examples
+sphinx-hoverxref


### PR DESCRIPTION
RtD's default build environment does not work.